### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -2,14 +2,17 @@
     Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
     Any future edits should abide by this format.
 -->
-
 # PAC Aurora backup service
 
 This service handles backups for AWS Aurora databases used by PAC (platform for annotation curation)
 
+## Code
+
+pac-aurora-backup
+
 ## Primary URL
 
-<https://github.com/Financial-Times/pac-aurora-backup>
+https://github.com/Financial-Times/pac-aurora-backup
 
 ## Service Tier
 
@@ -18,22 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- hristo.georgiev
-- elina.kaneva
-- mihail.mihaylov
-- robert.marinov
-- marina.chompalova
 
 ## Host Platform
 
@@ -51,9 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- pac-aurora
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -91,6 +88,14 @@ Manual
 ## Release Details
 
 The cronjob is deployed with Jenkins job. No failover is required as it is a Cronjob.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/pac-aurora-backup/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **pac-aurora-backup** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **pac-aurora-backup** system in [Biz Ops](https://biz-ops.in.ft.com/System/pac-aurora-backup).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
